### PR TITLE
Expand shorthand function so it works without transpiling

### DIFF
--- a/components/icon/Flag.vue
+++ b/components/icon/Flag.vue
@@ -14,7 +14,7 @@ export default {
         squared: { type: Boolean, default: true },
     },
     computed: {
-        flagIconClass() {
+        flagIconClass: function() {
             return ((!!this.squared) ? 'flag-icon-squared ' : '') + 'flag-icon-' + this.iso.toLowerCase();
         }
     }


### PR DESCRIPTION
A minor change to the `flagIconClass` computed method so it works without transpiling, specifically in IE11