### PR TITLE
add .vue extension to import

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -1,4 +1,4 @@
-import Flag from './icon/Flag'
+import Flag from './icon/Flag.vue'
 
 export {
     Flag


### PR DESCRIPTION
Extension-less imports aren't supported by Vite and won't be supported in vue-cli soon: https://github.com/vitejs/vite/issues/178