### PR TITLE
Move to flag-icons

### DIFF
--- a/components/icon/Flag.vue
+++ b/components/icon/Flag.vue
@@ -1,22 +1,22 @@
-<style>
-
-</style>
 <template>
-    <span v-if="iso" class="flag-icon" :class="flagIconClass" :title="title || iso">
-    </span>
+  <span v-if="iso" class="fi" :class="flagIconClass" :title="title || iso">
+  </span>
 </template>
+
 <script>
 export default {
-    name: 'flag',
-    props: {
-        iso: { type: String, default: null },
-        title: { type: String, default: null },
-        squared: { type: Boolean, default: true },
+  name: "flag",
+  props: {
+    iso: { type: String, default: null },
+    title: { type: String, default: null },
+    squared: { type: Boolean, default: true },
+  },
+  computed: {
+    flagIconClass() {
+      return (!!this.squared ? "fis " : "") + "fi-" + this.iso.toLowerCase();
     },
-    computed: {
-        flagIconClass: function() {
-            return ((!!this.squared) ? 'flag-icon-squared ' : '') + 'flag-icon-' + this.iso.toLowerCase();
-        }
-    }
-}
+  },
+};
 </script>
+
+<style></style>

--- a/components/index.js
+++ b/components/index.js
@@ -1,5 +1,3 @@
-import Flag from './icon/Flag.vue'
+import Flag from "./icon/Flag.vue";
 
-export {
-    Flag
-};
+export { Flag };

--- a/index.js
+++ b/index.js
@@ -1,18 +1,19 @@
-import './vendors'
-import { Flag } from './components'
+import "./vendors";
+
+import { Flag } from "./components";
 
 const VuePlugin = {
-    install: function (Vue) {
-        if (VuePlugin.installed) {
-            return;
-        }
-        VuePlugin.installed = true;
-        Vue.component('flag', Flag);
+  install: function (Vue) {
+    if (VuePlugin.installed) {
+      return;
     }
+    VuePlugin.installed = true;
+    Vue.component("flag", Flag);
+  },
 };
 
-if (typeof window !== 'undefined' && window.Vue) {
-    window.Vue.use(VuePlugin);
+if (typeof window !== "undefined" && window.Vue) {
+  window.Vue.use(VuePlugin);
 }
 
 export default VuePlugin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "vue-flag-icon",
+  "version": "2.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vue-flag-icon",
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "flag-icons": "^6.4.2"
+      }
+    },
+    "node_modules/flag-icons": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/flag-icons/-/flag-icons-6.4.2.tgz",
+      "integrity": "sha512-1zlIYDVcn5jQpF5aYWEAeO4WXuLHj4i6lQIZNjn8Kl6rcZperkUj79uHC9OUi2s+IEl9AYskW8JCx83/6KcmLw=="
+    }
+  },
+  "dependencies": {
+    "flag-icons": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/flag-icons/-/flag-icons-6.4.2.tgz",
+      "integrity": "sha512-1zlIYDVcn5jQpF5aYWEAeO4WXuLHj4i6lQIZNjn8Kl6rcZperkUj79uHC9OUi2s+IEl9AYskW8JCx83/6KcmLw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/vikkio88/vue-flag-icon#readme",
   "dependencies": {
-    "flag-icon-css": "^2.8.0"
+    "flag-icons": "^6.4.2"
   }
 }

--- a/vendors/index.js
+++ b/vendors/index.js
@@ -1,1 +1,1 @@
-import 'flag-icon-css/css/flag-icon.css'
+import "flag-icons/css/flag-icon.min.css";


### PR DESCRIPTION
Updated code to use `flag-icons` (flag-icon-css is deprecated in favor of flag-icons).