### PR TITLE
Update Flag.vue name to work for case-sensitive bundlers

### DIFF
--- a/components/icon/Flag.vue
+++ b/components/icon/Flag.vue
@@ -5,7 +5,7 @@
 
 <script>
 export default {
-  name: "flag",
+  name: "Flag",
   props: {
     iso: { type: String, default: null },
     title: { type: String, default: null },


### PR DESCRIPTION
In components/index.js we are importing import Flag from './icon/Flag' instead of import flag from './icon/Flag', therefore the name of the component needs to be updated to satisfy it

for example, it breaks for me when switching from in vue-cli to vite